### PR TITLE
feat: add GET /api/v1/books/{book_id} endpoint

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -60,3 +60,25 @@ async def update_book(book_id: int, book: Book) -> Book:
 async def delete_book(book_id: int) -> None:
     db.delete_book(book_id)
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
+
+
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int) -> Book:
+    """Get a specific book by ID.
+
+    Args:
+        book_id (int): The ID of the book to retrieve.
+
+    Returns:
+        Book: The requested book.
+
+    Raises:
+        HTTPException: If the book is not found.
+    """
+    book = db.get_book(book_id)
+    if not book:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Book not found"
+        )
+    return book

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -50,3 +50,10 @@ def test_delete_book():
 
     response = client.get("/books/3")
     assert response.status_code == 404
+
+
+def test_get_nonexistent_book():
+    """Test getting a book that doesn't exist returns 404."""
+    response = client.get("/books/999")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Book not found"


### PR DESCRIPTION
   ## Description
   - Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details
   - Added error handling for non-existent books
   - Added test coverage for the new endpoint
   
   ## Testing
   - Ran `pytest` locally (all tests passed)
   - Tested with both existing and non-existent book IDs
   
   ## Related Task
   [HNG12 Stage 2 Task - Book API Implementation]